### PR TITLE
Convert changeset hash to UUID for the telemetry pipeline

### DIFF
--- a/committelemetry/pulse.py
+++ b/committelemetry/pulse.py
@@ -88,9 +88,11 @@ def process_push_message(body, message, no_send=False):
             log.info(f'ping data (not sent): {ping}')
             continue
 
-        # Pings need a unique ID so they can be de-duplicated by the ingestion
-        # service.  We can use the changeset ID for the unique key.
-        send_ping(changeset, ping)
+        # Pings need a UUID so they can be de-duplicated by the ingestion
+        # service.  We construct a UUID here from the first 32 characters
+        # of the changeset hash.
+        ping_id = str(uuid.UUID(changeset[:32]))
+        send_ping(ping_id, ping)
 
     ack()
 

--- a/committelemetry/pulse.py
+++ b/committelemetry/pulse.py
@@ -8,6 +8,7 @@ See https://wiki.mozilla.org/Auto-tools/Projects/Pulse
 """
 import logging
 import socket
+import uuid
 from contextlib import closing
 from functools import partial
 

--- a/committelemetry/pushlog.py
+++ b/committelemetry/pushlog.py
@@ -65,6 +65,8 @@ def send_pings_by_pushid(repo_url, starting_push_id, ending_push_id, no_send):
                 log.info(f'ping data (not sent): {ping}')
                 continue
 
-            # Pings need a unique ID so they can be de-duplicated by the ingestion
-            # service.  We can use the changeset ID for the unique key.
-            send_ping(changeset, ping)
+            # Pings need a UUID so they can be de-duplicated by the ingestion
+            # service.  We construct a UUID here from the first 32 characters
+            # of the changeset hash.
+            ping_id = str(uuid.UUID(changeset[:32]))
+            send_ping(ping_id, ping)

--- a/committelemetry/pushlog.py
+++ b/committelemetry/pushlog.py
@@ -7,6 +7,7 @@ Functions related to processing mercurial pushlog messsages.
 See https://mozilla-version-control-tools.readthedocs.io/en/latest/hgmo/pushlog.html#writing-agents-that-consume-pushlog-data
 """
 import logging
+import uuid
 
 from committelemetry.http import requests_retry_session
 from committelemetry.telemetry import payload_for_changeset, send_ping

--- a/tests/test_process_hgpush.py
+++ b/tests/test_process_hgpush.py
@@ -43,7 +43,7 @@ def test_process_push_message():
     with patch('committelemetry.pulse.send_ping') as send_ping, \
          patch('committelemetry.pulse.payload_for_changeset'), \
          patch('committelemetry.pulse.changesets_for_pushid') as changesets_for_pushid:
-        changesets_for_pushid.return_value = ['ab1cd2']
+        changesets_for_pushid.return_value = ['1234567812345678123456781234567812345678']
 
         process_push_message(test_message, MagicMock())
 


### PR DESCRIPTION
The new telemetry pipeline in GCP is more strict about what it will accept
as a document ID compared to AWS. We now enforce that document IDs are
UUIDs in the standard 36-character hex representation.

Currently, `hgpush` payloads are failing validation and being sent to error
outputs in BigQuery due to using the 40-character changeset hash as document ID.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1597217